### PR TITLE
[DEV-3491] Feature - Datauri support for the HTTP env header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -332,6 +332,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
       "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA=="
     },
+    "@types/parse-data-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-data-url/-/parse-data-url-3.0.0.tgz",
+      "integrity": "sha512-W7j36KpA780hfh4jyQoLab3+uS+Svmug7GgdJoHe/4ak66ws6ar5/wD8Cqch01O+UT69pzfsBtpNzrF4/6ThBw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -3094,6 +3103,14 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "parse-data-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
+      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
+      "requires": {
+        "valid-data-url": "^4.0.0"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -4212,6 +4229,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "valid-data-url": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
+      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "@prezly/slate-renderer": "^0.1.2",
     "next": "^10.2.0",
     "next-seo": "^4.24.0",
+    "parse-data-url": "^4.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@types/node": "^15.0.1",
+    "@types/parse-data-url": "^3.0.0",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/utils/prezly/getEnvVariables.ts
+++ b/utils/prezly/getEnvVariables.ts
@@ -1,20 +1,40 @@
+import parseDataUrl from 'parse-data-url';
 import type { IncomingMessage } from 'http';
 import type { Env } from '../../types';
+
+const decodeJson = (json: string): Record<string, any> => {
+    try {
+        const decoded = JSON.parse(json);
+        if (decoded && typeof decoded === 'object') {
+            return decoded;
+        }
+    } catch {
+        // passthru
+    }
+    return {};
+};
+
+const decodeHttpEnv = (header: string): Record<string, any> => {
+    if (header.startsWith('data:')) {
+        const parsed = parseDataUrl(header);
+        if (parsed && parsed.contentType === 'application/json') {
+            return decodeJson(parsed.data);
+        }
+        return {}; // unsupported data-uri
+    }
+    return decodeJson(header);
+};
 
 const getEnvVariables = (req?: IncomingMessage): Env => {
     if (process.browser) {
         throw new Error('"getEnvVariables" should only be used on back-end side.');
     }
 
-    const envHeader = (process.env.HTTP_ENV_HEADER || '').toLowerCase();
+    const httpEnvHeader = (process.env.HTTP_ENV_HEADER || '').toLowerCase();
 
-    if (envHeader && req) {
-        try {
-            const envJson = req.headers[envHeader] as string;
-            return { ...process.env, ...JSON.parse(envJson) };
-        } catch {
-            // do nothing
-        }
+    if (httpEnvHeader && req) {
+        const httpEnv = decodeHttpEnv(httpEnvHeader);
+        return { ...process.env, ...httpEnv };
     }
 
     return { ...process.env };


### PR DESCRIPTION
- Add [parse-data-uri](https://www.npmjs.com/package/parse-data-uri) package dependency
- Parse `data:` strings as data URIs (needed to support base64-encoded headers; see DEV-3491)